### PR TITLE
Seperate futures so they can be polled independently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ futures-fs = "0.0.3"
 gotham = "0.2"
 gotham_derive = "0.2"
 hyper = "*"
+tokio = "0.1"
 
 [dev-dependencies]
 mime = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate gotham;
 #[macro_use]
 extern crate gotham_derive;
 extern crate hyper;
+extern crate tokio;
 
 pub mod body;
 pub mod response;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,8 +1,9 @@
 use std::io;
 
 use bytes::Bytes;
-use futures::{Future, Sink, Stream};
+use futures::{Future, Sink, Stream, future};
 use hyper::{header, Body, Chunk, Error, Response};
+use tokio::executor::{DefaultExecutor, Executor};
 
 pub trait WriteResponseStream {
     fn into_response(self) -> Box<Future<Item = Response<Body>, Error = Error>>;
@@ -10,7 +11,7 @@ pub trait WriteResponseStream {
 
 impl<S> WriteResponseStream for S
 where
-    S: Stream<Item = Bytes, Error = io::Error> + 'static,
+    S: Stream<Item = Bytes, Error = io::Error> + 'static + Send,
 {
     fn into_response(self) -> Box<Future<Item = Response<Body>, Error = Error>> {
         // Create a streamable body
@@ -20,15 +21,17 @@ where
         res.headers_mut().remove::<header::ContentLength>();
 
         // Convert sink errors to Hyper errors
-        let sender = sender.sink_map_err(|e| Error::from(io::Error::new(io::ErrorKind::Other, e)));
-        // Convert the byte stream to a Hyper chunk stream
-        let mapped = self.map(|bytes| {
-            println!("read chunk of {} bytes", bytes.len());
-            Ok(Chunk::from(bytes))
-        }).map_err(|err| Error::Io(err));
-        // Forward the read stream to the body stream
-        let f = mapped.forward(sender).and_then(|_| Ok(res));
+        let sender = sender
+            .sink_map_err(|e| Error::from(io::Error::new(io::ErrorKind::Other, e)));
 
-        Box::new(f)
+        let stream = self.map(|bytes| Ok(bytes.into()));
+
+        let streaming_future = sender.send_all(stream)
+            .map(|(_sink, _stream)| ())
+            .map_err(|_e| println!("not much we can do to fix this")); //error!("Error streaming from Fs to body")
+
+        DefaultExecutor::current().spawn(Box::new(streaming_future)).unwrap();
+
+        Box::new(future::ok(res))
     }
 }


### PR DESCRIPTION
Continuing from our discussion at https://github.com/gotham-rs/gotham/issues/189#issuecomment-384290466.
This separates the futures so they can be independently polled, fixing the stream deadlock.

One future is responsible for taking chunks from the file stream and putting them into the rendezvous channel sink created by Body::pair(), the other future takes from the channel stream (output) and writes to the network (this future is created later from the HandlerFuture which we return).

In the current code the second stream-sink future is never created because the hyper::response isn't created until the file stream is completely written to the channel, but the channel is never emptied because the response hasn't been created and polled. So it dead locks.